### PR TITLE
feat: Utilize lastmod from sitemap.xml in web connector

### DIFF
--- a/backend/onyx/utils/eea_utils.py
+++ b/backend/onyx/utils/eea_utils.py
@@ -47,10 +47,12 @@ def list_pages_for_site_eea(site):
         rp = init_robots_txt(site)
     except:
         logger.warning("Failed to load robots.txt")
+    urls_data = {}
     tree = sitemap_tree_for_homepage(site)
-    pages = [page.url for page in tree.all_pages() if test_url(rp, page)]
-    pages = list(dict.fromkeys(pages))
-    return(pages)
+    for page in tree.all_pages():
+        if test_url(rp, page):
+            urls_data[page.url] = page.last_modified
+    return urls_data
 
 def soer_login():
     login_url = "https://www.eea.europa.eu/++api++/@login"

--- a/backend/onyx/utils/sitemap.py
+++ b/backend/onyx/utils/sitemap.py
@@ -26,13 +26,17 @@ def _get_sitemap_locations_from_robots(base_url: str) -> Set[str]:
     return sitemap_urls
 
 
-def _extract_urls_from_sitemap(sitemap_url: str) -> Set[str]:
-    """Extract URLs from a sitemap XML file"""
-    urls: set[str] = set()
+def _extract_urls_from_sitemap(sitemap_url: str) -> dict[str, str | None]:
+    """Extract URLs and their lastmod values from a sitemap XML file
+
+    Returns:
+        Dictionary mapping URLs to their lastmod values (or None if not present)
+    """
+    urls_data: dict[str, str | None] = {}
     try:
         resp = requests.get(sitemap_url, timeout=10)
         if resp.status_code != 200:
-            return urls
+            return urls_data
 
         root = ET.fromstring(resp.content)
 
@@ -45,34 +49,42 @@ def _extract_urls_from_sitemap(sitemap_url: str) -> Set[str]:
             # This is a sitemap index
             for sitemap in root.findall(f".//{ns}loc"):
                 if sitemap.text:
-                    sub_urls = _extract_urls_from_sitemap(sitemap.text)
-                    urls.update(sub_urls)
+                    sub_url_data = _extract_urls_from_sitemap(sitemap.text)
+                    urls_data.update(sub_url_data)
         else:
             # This is a regular sitemap
-            for url in root.findall(f".//{ns}loc"):
-                if url.text:
-                    urls.add(url.text)
+            for url_elem in root.findall(f".//{ns}url"):
+                loc = url_elem.find(f"{ns}loc")
+                lastmod = url_elem.find(f"{ns}lastmod")
+
+                if loc is not None and loc.text:
+                    lastmod_value = lastmod.text if lastmod is not None else None
+                    urls_data[loc.text] = lastmod_value
 
     except Exception as e:
         logger.warning(f"Error processing sitemap {sitemap_url}: {e}")
 
-    return urls
+    return urls_data
 
 
-def list_pages_for_site(site: str) -> list[str]:
-    """Get list of pages from a site's sitemaps"""
+def list_pages_for_site(site: str) -> dict[str, str | None]:
+    """Get list of pages from a site's sitemaps with their lastmod values
+
+    Returns:
+        Dictionary mapping URLs to their lastmod values (or None if not present)
+    """
     site = site.rstrip("/")
-    all_urls = set()
+    all_urls_data: dict[str, str | None] = {}
 
     # Try both common sitemap locations
     sitemap_paths = ["/sitemap.xml", "/sitemap_index.xml"]
     for path in sitemap_paths:
         sitemap_url = urljoin(site, path)
-        all_urls.update(_extract_urls_from_sitemap(sitemap_url))
+        all_urls_data.update(_extract_urls_from_sitemap(sitemap_url))
 
     # Check robots.txt for additional sitemaps
     sitemap_locations = _get_sitemap_locations_from_robots(site)
     for sitemap_url in sitemap_locations:
-        all_urls.update(_extract_urls_from_sitemap(sitemap_url))
+        all_urls_data.update(_extract_urls_from_sitemap(sitemap_url))
 
-    return list(all_urls)
+    return all_urls_data


### PR DESCRIPTION
## Description

This update incorporates the lastmod value from the sitemap.xml file into the web connector's processing, allowing for more accurate content updates.

## How Has This Been Tested?

I've indexed some documents using a sitemap.xml with lastmod values, then, in the explorer, I've searched for something filtering by last updated

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
