### PR TITLE
feat(pdf): use pdf metadata title as semantic identifier

### DIFF
--- a/backend/onyx/connectors/web/connector.py
+++ b/backend/onyx/connectors/web/connector.py
@@ -566,12 +566,12 @@ class WebConnector(LoadConnector):
             page_text, metadata, images = read_pdf_file(
                 file=io.BytesIO(response.content))
             last_modified = response.headers.get("Last-Modified")
-
+            title = metadata.get("Title") or metadata.get("title")
             result.doc = Document(
                 id=initial_url,
                 sections=[TextSection(link=initial_url, text=page_text)],
                 source=DocumentSource.WEB,
-                semantic_identifier=initial_url.split("/")[-3 if "@@download/file" in initial_url else -1],
+                semantic_identifier=title or initial_url.split("/")[-3 if "@@download/file" in initial_url else -1],
                 metadata=metadata,
                 doc_updated_at=(_get_datetime_from_last_modified_header(
                     last_modified) if last_modified else None),


### PR DESCRIPTION
## Description

For PDFs fetched by the Web connector, set the document semantic_identifier to the PDF metadata title when available.

## How Has This Been Tested?

- **PDF with title**: Confirms semantic_identifier equals metadata title.
- **PDF without title**: Confirms fallback to id from URL.
- **Non-PDF content**: Confirms no change in behavior.
- **Mixed sitemap/pages**: Ensures only PDFs are affected and logging remains clean.

## Backporting (check the box to trigger backport action)

Note: You have to check that the action passes, otherwise resolve the conflicts manually and tag the patches.

- [ ] This PR should be backported (make sure to check that the backport attempt succeeds)
- [x] [Optional] Override Linear Check
