### PR TITLE
docs: document EEA custom patches for v2.12.1 merge

### DIFF
--- a/eea-artifacts/FORK.md
+++ b/eea-artifacts/FORK.md
@@ -1,0 +1,51 @@
+# EEA Fork Maintenance Context & Strategy
+
+## Introduction
+
+This repository is the EEA (European Environment Agency) fork of the **Onyx** (formerly Danswer) project. It contains a complex architecture with both backend and frontend services.
+
+Because we have a significant number of customizations tailored to EEA's needs, maintaining this fork requires a careful, methodical approach to ensure we can periodically bring in updates from the main Onyx repository without losing or breaking our customizations.
+
+**For AI Assistants:** Treat this file as the primary seed context when working in this repository. Ensure that any code changes, architectural decisions, and bug fixes consider the long-term maintainability of our fork against upstream Onyx changes.
+
+---
+
+## Branching Strategy
+
+- **`eea` Branch**: This is our **main branch of development**. All EEA-specific features, customizations, and bug fixes reside here. When deploying or testing our environment, the `eea` branch is the source of truth.
+- **Upstream Branches / Tags**: We track the main Onyx repository releases (e.g., `v2.12.1`).
+
+---
+
+## Update & Patch Strategy
+
+To ensure seamless integration of upstream Onyx releases, we adhere to the following workflow:
+
+1. **Targeting a Release**: We periodically identify a stable Onyx release (e.g., `v2.12.1`) as our target to merge into our fork.
+2. **Patch Documentation**: Every customization or deviation from upstream Onyx **must** be documented in `eea-artifacts/patches-overview.md`. This allows us to track exactly what we changed, why we changed it, and where the changes live.
+3. **Isolating Customizations**: When writing new features or modifying existing Onyx code:
+   - Try to isolate EEA features by placing them in separate, newly created files or modules whenever possible.
+   - If modifying an existing upstream file is unavoidable, clearly delineate the change with concise comments (e.g., `// EEA CUSTOMIZATION: ...`) so it is trivial to identify during a merge conflict.
+4. **Merge Process**:
+   - Fetch the upstream Onyx tags/releases.
+   - Merge the targeted release tag into a temporary upgrade branch based on `eea`.
+   - Resolve conflicts by referring to `eea-artifacts/patches-overview.md` to ensure our customizations are preserved.
+   - Review and test before completing the merge back into the `eea` branch.
+
+---
+
+## Guidelines for AI Assistants working in this repo
+
+When you (the AI assistant) are tasked with creating a feature, modifying code, or resolving conflicts in this repository, you must:
+
+1. **Read `eea-artifacts/patches-overview.md`** first to understand existing customizations.
+2. **Prioritize Upstream Compatibility**: Avoid massive structural refactors of upstream Onyx files. Instead, use hooks, subclassing, overriding, or isolated components wherever the language/framework permits.
+3. **Document Your Patches**: If you introduce a new deviation from the upstream codebase, update `eea-artifacts/patches-overview.md` with:
+   - The file(s) modified.
+   - The nature of the change.
+   - The reasoning behind it.
+   - Any potential upstream conflicts it might cause.
+4. **Keep it Clean**: Write clear, standard, and highly readable code. Do not introduce messy dependencies that conflict with Onyx's primary `package.json` or `requirements.txt` / `pyproject.toml` unless strictly necessary for EEA.
+5. **Git Commands**: Always run git commands with the `--no-pager` option (e.g., `git --no-pager diff`, `git --no-pager log`). The environment is configured with a visual diff tool that may cause issues or hang when run without this option in the associated agentic terminal.
+
+By following this strategy, we can leverage the powerful features developed by the Onyx community while securely and reliably serving EEA's specific organizational and user needs.

--- a/eea-artifacts/FORK.md
+++ b/eea-artifacts/FORK.md
@@ -46,6 +46,6 @@ When you (the AI assistant) are tasked with creating a feature, modifying code, 
    - The reasoning behind it.
    - Any potential upstream conflicts it might cause.
 4. **Keep it Clean**: Write clear, standard, and highly readable code. Do not introduce messy dependencies that conflict with Onyx's primary `package.json` or `requirements.txt` / `pyproject.toml` unless strictly necessary for EEA.
-5. **Git Commands**: Always run git commands with the `--no-pager` option (e.g., `git --no-pager diff`, `git --no-pager log`). The environment is configured with a visual diff tool that may cause issues or hang when run without this option in the associated agentic terminal.
+5. **Git Commands**: To avoid issues with visual diff tools or interactive pagers in the terminal, always prefix git commands with `env GIT_PAGER=cat` (e.g., `env GIT_PAGER=cat git diff`). This ensures that the output is printed directly to the terminal without hanging or requiring user interaction.
 
 By following this strategy, we can leverage the powerful features developed by the Onyx community while securely and reliably serving EEA's specific organizational and user needs.

--- a/eea-artifacts/patches-overview.md
+++ b/eea-artifacts/patches-overview.md
@@ -24,4 +24,72 @@ To add a new patch, please duplicate the template below.
 
 ## Documented Patches
 
-_(Currently empty. Add new EEA-specific patches here as they are created.)_
+- **Patch Name/ID:** `[EEA-001] Custom Jenkins & Git CI/CD`
+- **Files Modified:** `Jenkinsfile`, `deployment/.gitignore`, `backend/Dockerfile`, `backend/Dockerfile.model_server`
+- **Description:** Adds Jenkins pipelines, custom Docker build arguments, and tweaks dockerfiles to support EEA's build infrastructure.
+- **Potential Upstream Conflicts:** Low to Moderate. Dockerfile changes might conflict if upstream restructures underlying OS or python versions.
+- **Migration Strategy:** Maintain Jenkinsfile separately. Re-apply custom dockerfile arguments if `backend/Dockerfile` changes structurally upstream.
+
+---
+
+- **Patch Name/ID:** `[EEA-002] Playwright & Scraping Customizations`
+- **Files Modified:** `backend/onyx/utils/playwright.py`, `backend/onyx/utils/sitemap.py`, `backend/chromium-linux.zip.part.*`, `backend/ffmpeg-linux.zip`
+- **Description:** Adjusts Playwright behavior (added timeouts, optimistic disconnect handling, exclude elements by selector), allows scraping with expired SSL certificates, and includes offline chromium/ffmpeg binaries to avoid downloading them at runtime.
+- **Potential Upstream Conflicts:** Moderate. `sitemap.py` and scraping utilities might receive upstream improvements that conflict.
+- **Migration Strategy:** Carry over the offline binaries and the custom timeout/ssl settings into the new crawler utility versions upon merging.
+
+---
+
+- **Patch Name/ID:** `[EEA-003] EEA Config & Admin Pages`
+- **Files Modified:** `backend/onyx/server/eea_config/*`, `web/src/app/admin/eea_config/*`, `web/src/app/pages/*`, `web/src/lib/eea/fetchEEASettings.ts`, `backend/onyx/utils/eea_utils.py`
+- **Description:** Adds a custom dynamic configuration module to manage specific EEA parameters (like footer links, disclaimer options) directly from the admin panel, as well as the ability to create dynamic pages.
+- **Potential Upstream Conflicts:** Low for backend since files are isolated. Moderate for frontend where admin sidebar/routing (`web/src/sections/sidebar/AdminSidebar.tsx`) and `layout.tsx` are modified.
+- **Migration Strategy:** The isolated files will migrate cleanly. The integration points in `AdminSidebar.tsx`, API routers, and layout components will need manual conflict resolution.
+
+---
+
+- **Patch Name/ID:** `[EEA-004] Frontend Customizations (Logos, UI, Disclaimer, Chat)`
+- **Files Modified:** `web/public/EEA_logo*`, `web/src/components/logo/*`, `web/src/components/EEA_Logo.tsx`, `web/src/app/auth/*`, `web/src/app/layout.tsx`, `web/src/app/chat/components/WelcomeMessage.tsx`, `web/src/components/auth/AuthFlowContainer.tsx`
+- **Description:** Replaces Onyx branding with EEA branding. Updates the login/signup pages, header, footer, and chat layout. Adds a custom disclaimer modal when a user logs in.
+- **Potential Upstream Conflicts:** High. These are core UI files (Login, Layout, Chatbar) which upstream changes frequently.
+- **Migration Strategy:** Carefully re-apply branding and disclaimer modal checks inside the updated upstream layout and login components during the upgrade.
+
+---
+
+- **Patch Name/ID:** `[EEA-005] Custom Background Tasks & Celery Tweaks`
+- **Files Modified:** `backend/onyx/background/celery/tasks/eea/*`, `backend/onyx/background/celery/tasks/beat_schedule.py`, `backend/onyx/background/celery/apps/primary.py`, `backend/onyx/background/celery/apps/light.py`
+- **Description:** Adds EEA-specific scheduled tasks and celery worker configurations. Modifies the beat schedule to include these custom tasks.
+- **Potential Upstream Conflicts:** Moderate. Upstream registry `beat_schedule.py` might have new tasks added.
+- **Migration Strategy:** Keep `eea/tasks.py` isolated. Re-inject the schedule into `beat_schedule.py` and worker configs manually upon merge.
+
+---
+
+- **Patch Name/ID:** `[EEA-006] Helm Chart Customizations for EEA Infrastructure`
+- **Files Modified:** `deployment/helm/charts/onyx/templates/postgresql-*`, `deployment/helm/charts/onyx/templates/redis-*`, `deployment/helm/charts/onyx/templates/vespa-*`, `deployment/docker_compose/eea/*`, `deployment/helm/charts/onyx/templates/network-policies.yaml`, `deployment/helm/charts/onyx/templates/nginx-ingress.yaml`, `deployment/helm/charts/onyx/templates/nginx-simple.yaml`
+- **Description:** Adds backup cronjobs, PVCs, custom network policies, and a different ingress setup for EEA's Kubernetes environment. Disables/moves upstream ingress templates.
+- **Potential Upstream Conflicts:** High. Upstream Helm chart version bumps and template restructuring.
+- **Migration Strategy:** Retain the EEA-specific YAML templates. If upstream made changes to statefulsets/deployments, ensure our backup cronjobs and PVCs still attach correctly.
+
+---
+
+- **Patch Name/ID:** `[EEA-007] Connector Healthchecks & Workarounds`
+- **Files Modified:** `backend/onyx/server/manage/connectors_state.py`, `backend/onyx/connectors/*`, `backend/onyx/background/indexing/job_client.py`
+- **Description:** Adds connector healthcheck endpoints, tweaks failure handling (wait for 2 consecutive failures before pausing), and provides workarounds for connector deletion and un-reachable indexing models.
+- **Potential Upstream Conflicts:** Moderate. Upstream is actively improving connectors and indexing logic.
+- **Migration Strategy:** Carefully review upstream connector management during the merge. Some workarounds may no longer be needed if upstream fixed the underlying bug.
+
+---
+
+- **Patch Name/ID:** `[EEA-008] LLM & Auth Minor Tweaks`
+- **Files Modified:** `backend/onyx/auth/email_utils.py`, `backend/onyx/llm/chat_llm.py`, `backend/onyx/llm/utils.py`
+- **Description:** Minor tweaks for SMTP authentication (don't auth if credentials are missing), handling Meta-Llama `MAX_TOKENS` special cases, and fallback encoding.
+- **Potential Upstream Conflicts:** Low.
+- **Migration Strategy:** Re-apply the specific conditional lines to the updated upstream files.
+
+---
+
+- **Patch Name/ID:** `[EEA-009] Upstream Backports & Hotfixes`
+- **Files Modified:** Various backend files (e.g., `alembic` revisions, Confluence `handleRequest` fix).
+- **Description:** Commits cherry-picked from newer Onyx versions before doing a full upgrade to fix urgent bugs.
+- **Potential Upstream Conflicts:** Low. Git should handle exact cherry-picks cleanly.
+- **Migration Strategy:** Upon merging `v2.12.1`, git will likely auto-resolve these. If conflicts arise, accept the upstream `v2.12.1` version of the file since it contains the official fix.

--- a/eea-artifacts/patches-overview.md
+++ b/eea-artifacts/patches-overview.md
@@ -1,0 +1,27 @@
+# EEA Customizations & Patches Overview
+
+This document records the specific customizations and patches made in the `eea` branch of our fork of the Onyx (formerly Danswer) repository. Keeping track of these changes is essential when migrating our fork to newer upstream Onyx versions.
+
+## Current Merge Target
+
+**Target Upstream Version:** `v2.12.1`
+
+Whenever an EEA-specific customization is created or modified, or an upstream feature requires an EEA patch to work, document it here.
+
+---
+
+### Patch Record Template
+
+To add a new patch, please duplicate the template below.
+
+- **Patch Name/ID:** (e.g., `[EEA-001] Custom SSO Authentication`)
+- **Files Modified:** (List of files touched by this patch)
+- **Description:** (What does this patch do? Why is it necessary for EEA?)
+- **Potential Upstream Conflicts:** (What parts of the original code were overridden that might break during an upgrade?)
+- **Migration Strategy:** (How to carry this patch forward or reintegrate it if upstream changes significantly)
+
+---
+
+## Documented Patches
+
+_(Currently empty. Add new EEA-specific patches here as they are created.)_


### PR DESCRIPTION
This PR documents the EEA-specific patches currently present in our fork to prepare for the merge with upstream v2.12.1. 

A new artifact  has been created/updated with 9 logical patch groups identified from the diff against the v2.12.1 merge base.